### PR TITLE
Allow New Connect URL Format

### DIFF
--- a/monitoring-stack-cdk/lib/monitoring-stack.ts
+++ b/monitoring-stack-cdk/lib/monitoring-stack.ts
@@ -24,7 +24,7 @@ export default class MonitoringStack extends cdk.Stack {
     if (
       ccpUrl == undefined 
       || !ccpUrl.startsWith('https://') 
-      || !(ccpUrl.includes('.awsapps.com') || ccpUrl.includes('.my.connect.aws'))
+      || !(ccpUrl.includes('.awsapps.com') || !ccpUrl.includes('.my.connect.aws'))
       || !ccpUrl.includes('/ccp-v2') ) {
         throw(new Error('CCP URL must be the https:// url to your ccp-v2 softphone'));
       }


### PR DESCRIPTION
Assuming that we should allow the CCP URL to have `.my.connect.aws` or it will throw an error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
